### PR TITLE
Make it compatible with ghc 8.4 and higher

### DIFF
--- a/HGL.cabal
+++ b/HGL.cabal
@@ -22,7 +22,7 @@ flag split-base
 
 library
   if flag(split-base)
-    build-depends: base >= 4.4.0.0 && < 5, array
+    build-depends: base >= 4.4.0.0 && < 5, array, stm
   else
     build-depends: base < 2
   exposed-modules:


### PR DESCRIPTION
As `isEmptyChan` was removed by http://hackage.haskell.org/trac/ghc/ticket/4154, we can follow
suggestions in there and just replace Chan with TChan.

fixes #3